### PR TITLE
IntersectionObserver 🔥

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -6,8 +6,8 @@
             :ref="'card' + index"
         >
             <Map
-                :lon="theater.lon"
-                :lat="theater.lat"
+                :lon="lon"
+                :lat="lat"
             />
             <Details
                 :distance="theater.distance"
@@ -30,6 +30,13 @@ export default {
         Details
     },
 
+    data() {
+        return {
+            lat: null,
+            lon: null
+        };
+    },
+
     props: {
         theater: {
             type: Object,
@@ -39,6 +46,30 @@ export default {
         index: {
             type: Number,
             required: true
+        }
+    },
+
+    mounted() {
+        const oberverOptions = {
+            root: null,
+            rootMargin: "0px",
+            threshold: 0.2
+        };
+
+        this.observer = new IntersectionObserver(this.loadMap, oberverOptions);
+
+        this.observer.observe(this.$refs["card" + this.index]);
+    },
+
+    methods: {
+        loadMap(changes, observer) {
+            changes.forEach((change) => {
+                if (change.intersectionRatio > 0) {
+                    this.lon = this.theater.lon;
+                    this.lat = this.theater.lat;
+                    this.observer.unobserve(this.$refs["card" + this.index]);
+                }
+            });
         }
     }
 };

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -50,13 +50,13 @@ export default {
     },
 
     mounted() {
-        const oberverOptions = {
+        const observerOptions = {
             root: null,
             rootMargin: "0px",
             threshold: 0.2
         };
 
-        this.observer = new IntersectionObserver(this.loadMap, oberverOptions);
+        this.observer = new IntersectionObserver(this.loadMap, observerOptions);
 
         this.observer.observe(this.$refs["card" + this.index]);
     },

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -50,19 +50,23 @@ export default {
     },
 
     mounted() {
-        const observerOptions = {
-            root: null,
-            rootMargin: "0px",
-            threshold: 0.2
-        };
+        if ("IntersectionObserver" in window) {
+            const observerOptions = {
+                root: null,
+                rootMargin: "0px",
+                threshold: 0.2
+            };
 
-        this.observer = new IntersectionObserver(this.loadMap, observerOptions);
+            this.observer = new IntersectionObserver(this.onIntersection, observerOptions);
 
-        this.observer.observe(this.$refs["card" + this.index]);
+            this.observer.observe(this.$refs["card" + this.index]);
+        } else {
+            this.loadMap;
+        }
     },
 
     methods: {
-        loadMap(changes, observer) {
+        onIntersection(changes, observer) {
             changes.forEach((change) => {
                 if (change.intersectionRatio > 0) {
                     this.lon = this.theater.lon;
@@ -70,6 +74,11 @@ export default {
                     this.observer.unobserve(this.$refs["card" + this.index]);
                 }
             });
+        },
+
+        loadMap() {
+            this.lon = this.theater.lon;
+            this.lat = this.theater.lat;
         }
     }
 };

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -66,9 +66,9 @@ export default {
     },
 
     methods: {
-        onIntersection(changes, observer) {
-            changes.forEach((change) => {
-                if (change.intersectionRatio > 0) {
+        onIntersection(entries, observer) {
+            entries.forEach((entry) => {
+                if (entry.intersectionRatio > 0) {
                     this.lon = this.theater.lon;
                     this.lat = this.theater.lat;
                     this.observer.unobserve(this.$refs["card" + this.index]);

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="c-mapContainer">
-        <div class="c-map">
+        <div
+            v-if="lat"
+            class="c-map"
+        >
             <v-map
                 :zoom="zoom"
                 :center="[lat, lon]"
@@ -34,17 +37,7 @@ export default {
         "v-marker": Vue2Leaflet.Marker
     },
 
-    props: {
-        lat: {
-            type: Number,
-            required: true
-        },
-
-        lon: {
-            type: Number,
-            required: true
-        }
-    },
+    props: ["lat", "lon"],
 
     data() {
         return {


### PR DESCRIPTION
- Lazy load Leaflet maps using IntersectionObserver when the map containers pass 20% visibility threshold in the viewport
- In browsers without IntersectionObserver support, load all maps at once